### PR TITLE
update for laravel 8 and php8.* compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: php
 
 php:
-  - 7.1
+  - 8.0
 
 matrix:
   fast_finish: true

--- a/changelog.md
+++ b/changelog.md
@@ -4,5 +4,9 @@ All notable changes to `LaravelGoogleReCaptchaV2` will be documented in this fil
 
 ## Version 1.0
 
-### Added
-- Everything
+### Updated
+- update PHP version to ^7.2.5 || ^8.0.
+- update guzzlehttp/guzzle dependency to version 7.0 or higher.
+- update phpunit/phpunit dependency to version 9.0 or higher.
+- update orchestra/testbench dependency to version 6.0 or higher.
+- update "php-coveralls/php-coveralls" dependency to version 2.4 or higher.

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         "laravel"
     ],
     "require": {
-        "php": ">=5.5",
-        "guzzlehttp/guzzle": "^6.2"
+        "php": "^7.2.5 || ^8.0",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.0",
-        "orchestra/testbench": "~3.0",
-        "php-coveralls/php-coveralls": "^2.1"
+        "phpunit/phpunit": "~9.0",
+        "orchestra/testbench": "^6.0",
+        "php-coveralls/php-coveralls": "^2.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Update dependency for php8 compatibility.
Somehow, travisci does not support php8.*